### PR TITLE
Django 1.11 is out

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
 envlist =
-    {py27,py34}-{dj17,dj18,dj19}
+    {py27,py34}-{dj18,dj110,dj111}
 
 [testenv]
 commands = python setup.py test
 deps =
-    dj17: Django>=1.7,<1.8
     dj18: Django>=1.8,<1.9
-    dj19: Django>=1.9,<1.10
+    dj110: Django>=1.10,<1.11
+    dj111: Django>=1.11,<2.0


### PR DESCRIPTION
Test against officially supported versions

Project will still work with Django 1.4+ but we are not testing against that and is officially unsupported.