### PR TITLE
updated README.rst to include install instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,6 +35,12 @@ Aditioanlly if you want translations to work you need to add it to installed app
         'django_clamd',
         ...
     )
+    
+    
+Additionally if you are using Ubuntu, in order for django-clamd to work install clamav-daemon.
+
+.. code-block:: bash
+    sudo apt-get install clamav-daemon
 
 
 Usage


### PR DESCRIPTION
Additionally if you are using Ubuntu, in order for django-clamd to work install clamav-daemon.
    sudo apt-get install clamav-daemon