### PR TITLE
Ensure compatibility w/ Django 4.0.0

### DIFF
--- a/src/django_clamd/validators.py
+++ b/src/django_clamd/validators.py
@@ -2,7 +2,7 @@ import warnings
 import logging
 
 from django.core.exceptions import ValidationError
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from django_clamd import get_scanner
 from .conf import CLAMD_ENABLED


### PR DESCRIPTION
Replace calls to the deprecated - and as of Django 4, unavailable - `django.utils.translation.ugettext_lazy` method.
Since the method was an alias for `gettext_lazy`, this does not introduce a change in behavior.