### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -9,6 +9,9 @@ on:
 jobs:
   build:
 
+    permissions:
+      contents: read
+
     runs-on: ubuntu-latest
 
     services:


### PR DESCRIPTION
Potential fix for [https://github.com/vstoykov/django-clamd/security/code-scanning/1](https://github.com/vstoykov/django-clamd/security/code-scanning/1)

In general, to fix this problem you add an explicit `permissions:` block to the workflow (either at the root or per-job) that grants only the minimal set of scopes the job actually needs. For simple CI workflows that only check out code and run tests, `contents: read` is usually sufficient, as no write operations or other privileged actions are required.

For this specific workflow, the safest and simplest fix that preserves existing behavior is to add a job-level `permissions:` block under `jobs.build:` (or a top-level one, but we’ll keep the change local to the shown job). Since the job only checks out code and runs tests, it should only need read access to repository contents. We will therefore add:

```yaml
permissions:
  contents: read
```

indented to align correctly beneath `build:` and above `runs-on:`. No other functionality changes are needed, and no additional imports or methods are required because this is a pure YAML configuration change in `.github/workflows/python.yaml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
